### PR TITLE
ci: adopt canonical php-module template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,52 @@
+# Managed by netresearch/.github/templates/skill/
+#
+# Declares only the ecosystems every skill consumer is guaranteed to have:
+# github-actions (CI workflows) and composer (every skill repo ships a
+# composer.json for split-licensing / Packagist distribution).
+#
+# npm and devcontainers are OPT-IN: a repo that actually has package.json
+# fixtures (e.g. skills/<name>/references/examples/**) or a devcontainer adds
+# the block below to its own dependabot.yml and lists `.github/dependabot.yml`
+# under `intentional-drift:` in .github/template.yaml so the template sync
+# stops managing the file. Declaring an ecosystem without its manifest makes
+# the Dependabot run fail with `dependency_file_not_found`.
+#
+# Opt-in npm (use Dependabot's plural `directories:` to consolidate multiple
+# fixture dirs into one grouped PR):
+#   - package-ecosystem: npm
+#     directories:
+#       - /skills/<name>/references/examples/<project>
+#     schedule:
+#       interval: weekly
+#       day: monday
+#     open-pull-requests-limit: 5
+#     groups:
+#       npm:
+#         patterns: ['*']
+#     cooldown:
+#       default-days: 7
 version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
     groups:
       github-actions:
-        patterns:
-          - "*"
+        patterns: ['*']
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      composer:
+        patterns: ['*']
+    cooldown:
+      default-days: 7

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,15 @@
+documentation:
+  - changed-files:
+      - any-glob-to-any-file: ['**/*.md', 'docs/**/*', '**/SKILL.md', 'README.md']
+ci:
+  - changed-files:
+      - any-glob-to-any-file: ['.github/**/*', 'Makefile']
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file: ['composer.json', 'composer.lock', 'package.json', 'package-lock.json', 'bun.lock', 'bun.lockb', 'yarn.lock', '.devcontainer/**/*']
+skill:
+  - changed-files:
+      - any-glob-to-any-file: ['skills/**/*', '.claude-plugin/**/*', 'plugin.json']
+evals:
+  - changed-files:
+      - any-glob-to-any-file: ['**/evals/**/*', '**/eval/**/*', '**/*.eval.yaml', '**/*.eval.yml']

--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -1,0 +1,11 @@
+# Managed by netresearch/.github/templates/php-module/
+# Drift from the template is blocking CI in this repo (check-template-drift.yml).
+# Record explicit exceptions under intentional-drift[] to unblock.
+#
+# For PHP modules (Magento 2 / Shopware 6 / composer SDKs). CI surface is the
+# security/quality reusables with explicit per-call-site permissions (immune to
+# a restricted default_workflow_permissions). CodeQL is via GitHub default setup
+# (a repo setting), so no codeql.yml here. Add a test workflow per repo as
+# needed and list it under intentional-drift.
+template: php-module
+intentional-drift: []

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,59 +1,16 @@
-# Auto-merge bot PRs: Dependabot, Renovate, and release-please.
-# Requires: branch protection with required status checks (--auto flag needs it).
-#
-# SECURITY: This workflow uses pull_request_target which runs with base branch
-# permissions. NEVER add an actions/checkout step here -- that would allow code
-# from the PR to execute with write access to the repository.
-
-name: Auto-merge bot PRs
+name: Auto-merge dependency PRs
 
 on:
-    pull_request_target:
-        types: [opened, synchronize, reopened]
+  # auto-merge only calls `gh pr merge` via the reusable with the base-repo
+  # token; it never checks out or runs PR head code, so pull_request_target
+  # (required for a write token on Dependabot/Renovate fork PRs) is safe here.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
 
-permissions:
-    contents: write
-    pull-requests: write
+permissions: {}
 
 jobs:
-    auto-merge:
-        name: Auto-merge bot PRs
-        runs-on: ubuntu-24.04
-        # Use user.login instead of actor -- actor can change on synchronize/rerun.
-        # release-please PRs come from github-actions[bot]; scope with label check
-        # to avoid approving unrelated github-actions PRs.
-        if: >-
-            github.event.pull_request.user.login == 'dependabot[bot]' ||
-            github.event.pull_request.user.login == 'renovate[bot]' ||
-            (github.event.pull_request.user.login == 'github-actions[bot]' &&
-             contains(github.event.pull_request.labels.*.name, 'autorelease: pending'))
-
-        steps:
-            - name: Harden Runner
-              uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-              with:
-                  egress-policy: audit
-
-            - name: Dependabot metadata
-              id: metadata
-              if: github.event.pull_request.user.login == 'dependabot[bot]'
-              uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
-              with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-
-            - name: Auto-approve PR
-              # Skip for github-actions[bot] -- GITHUB_TOKEN can't approve
-              # its own PRs. release-please PRs need approval from pr-quality.yml
-              # using APPROVE_TOKEN, or manual approval.
-              if: github.event.pull_request.user.login != 'github-actions[bot]'
-              env:
-                  PR_URL: ${{ github.event.pull_request.html_url }}
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: gh pr review --approve "$PR_URL"
-
-            - name: Enable auto-merge
-              env:
-                  PR_URL: ${{ github.event.pull_request.html_url }}
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              # --auto waits for required status checks before merging
-              run: gh pr merge --auto --rebase "$PR_URL"
+  auto-merge:
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
+    permissions:
+      contents: write
+      pull-requests: write

--- a/.github/workflows/check-template-drift.yml
+++ b/.github/workflows/check-template-drift.yml
@@ -1,0 +1,17 @@
+name: Template Drift
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+  merge_group:
+
+permissions: {}
+
+jobs:
+  drift:
+    uses: netresearch/.github/.github/workflows/check-template-drift.yml@main
+    with:
+      template: php-module
+    permissions:
+      contents: read

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,23 @@
+name: OpenSSF Scorecard
+
+# Supply-chain posture scoring (branch protection, pinned actions, token
+# permissions, …). Runs on default-branch push and on a weekly schedule;
+# results upload to the code-scanning dashboard.
+
+on:
+  push:
+    branches: [main, master]
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  scorecard:
+    uses: netresearch/.github/.github/workflows/scorecard.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+      actions: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,14 +1,39 @@
 name: Security
 
+# Aggregated security scans: secret scanning (gitleaks), dependency review on
+# PRs, and a composer audit (every PHP module ships a composer.json).
+#
+# Top-level `permissions: {}` denies everything by default; each reusable
+# caller job re-declares the exact union its reusable's jobs require, so the
+# token passed to each reusable is fully explicit and never relies on the
+# repo default. This is the same pattern proven in netresearch/.github's
+# go-app template (top {} + per-job security-events: write).
+
 on:
-  pull_request:
-    branches: [main, master]
   push:
     branches: [main, master]
+  pull_request:
+
+permissions: {}
 
 jobs:
-  node-audit:
-    uses: netresearch/.github/.github/workflows/node-audit.yml@main
-    with:
-      package-manager: yarn
-      audit-level: high
+  gitleaks:
+    uses: netresearch/.github/.github/workflows/gitleaks.yml@main
+    permissions:
+      contents: read
+      security-events: write
+    secrets:
+      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    uses: netresearch/.github/.github/workflows/dependency-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+
+  composer-audit:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
+    permissions:
+      contents: read
+      security-events: write


### PR DESCRIPTION
Migrate CI to the canonical `php-module` template (netresearch/.github): explicit per-call-site permissions on every reusable, drift-enforced. CodeQL via default setup.