### PR TITLE
chore(renovate): hold TypeScript below v7

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,13 @@
     ":automergeMinor",
     ":automergePatch"
   ],
-  "platformAutomerge": true
+  "platformAutomerge": true,
+  "packageRules": [
+    {
+      "description": "Hold TypeScript below v7 until typescript-eslint and typedoc publish TS7 peer support (currently <6.1.0 and <=6.0.x). TS7 also removes baseUrl and moduleResolution=node10, which tsconfig still relies on; migrate tsconfig before lifting this.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7"
+    }
+  ]
 }


### PR DESCRIPTION
Renovate has been proposing `typescript@^7.0.0` (#593). TypeScript 7 is not installable in this repo today, so the PR cannot go green.

## Why

Three independent blockers, all verified:

1. **Toolchain has no TS7 release.** `typescript-eslint` declares peer `typescript@">=4.8.4 <6.1.0"` and `typedoc` declares `5.0.x … 6.0.x`. Neither has published a TS7-compatible version, so npm fails with `ERESOLVE` and eslint crashes at module load (`Cannot read properties of undefined (reading 'Cjs')`).
2. **tsconfig needs migrating.** TS7 removed `baseUrl` (`error TS5102`) and `moduleResolution=node10` (`error TS5108`); `tsconfig.json` still sets both.
3. **Ordering.** Even with tsconfig migrated, Lint and audit stay red until upstream ships TS7 peer support.

## What this does

Pins Renovate to `typescript@<7` so it stops opening a PR that cannot pass. The `description` field records the exact condition for lifting the rule.

## Follow-up

Lift the rule once `typescript-eslint` and `typedoc` publish TS7 peer ranges, and land the tsconfig migration (`paths` mapping + `node16`/`bundler`) before the bump.

Closes #593