### PR TITLE
ci: centralize external actions (Release Please + docs Pages)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,53 +5,30 @@ on:
     push:
         branches: [main]
 
-permissions:
-    contents: read
-    pages: write
-    id-token: write
-
 # Allow one concurrent deployment
 concurrency:
     group: 'pages'
     cancel-in-progress: true
 
-env:
-    HUSKY: '0'
-
 jobs:
     build:
         name: 📖 Build docs
-        runs-on: ubuntu-24.04
-        steps:
-            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-            - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-
-            - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-              with:
-                  node-version: '24'
-
-            - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-
-            - name: ⚡ Install dependencies
-              run: bun install --frozen-lockfile
-
-            - name: 🔨 Build documentation
-              run: bun run build:docs
-
-            - name: Upload artifact
-              uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
-              with:
-                  path: docs
+        uses: netresearch/.github/.github/workflows/pages-build.yml@main
+        permissions:
+            contents: read
+        with:
+            setup-node: true
+            node-version: '24'
+            setup-bun: true
+            artifact-path: docs
+            pre-build-command: HUSKY=0 bun install --frozen-lockfile
+            build-command: bun run build:docs
 
     deploy:
         name: 📦🚀 Deploy
-        environment:
-            name: github-pages
-            url: ${{ steps.deployment.outputs.page_url }}
-        runs-on: ubuntu-latest
         needs: build
-        steps:
-            - name: Deploy to GitHub Pages
-              id: deployment
-              uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        uses: netresearch/.github/.github/workflows/pages-deploy.yml@main
+        permissions:
+            pages: write
+            id-token: write
+            contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,16 +7,13 @@ on:
     push:
         branches: [main]
 
-permissions:
-    contents: write
-    pull-requests: write
-
 jobs:
     release-please:
         name: 📋 Release Please
-        runs-on: ubuntu-24.04
-        steps:
-            - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
-              with:
-                  release-type: node
-                  skip-github-release: true
+        uses: netresearch/.github/.github/workflows/release-please.yml@main
+        permissions:
+            contents: write
+            pull-requests: write
+        with:
+            release-type: node
+            skip-github-release: true


### PR DESCRIPTION
Removes direct external action pins in favour of the shared `netresearch/.github` reusables, per the "actions live only in shared workflows" policy.

- `release-please.yml` → `release-please.yml@main` reusable ([#321](https://github.com/netresearch/.github/pull/321)).
- `docs.yml` → `pages-build.yml@main` (with `setup-bun`, [#322](https://github.com/netresearch/.github/pull/322)) + `pages-deploy.yml@main`.

Note: `Node.js Audit` failure is pre-existing and not a required check (green on main).